### PR TITLE
add blocking dependency count to `ent list` and `ent show`

### DIFF
--- a/src/bin/ent/main.rs
+++ b/src/bin/ent/main.rs
@@ -194,7 +194,7 @@ fn handle_command(
                     let issue = issues.issues.get(*uuid).unwrap();
                     let comments = match issue.comments.len() {
                         0 => String::from("  "),
-                        n => format!("🗨️{}", n),
+                        n => format!("🗨️ {}", n),
                     };
                     let blocking_dependencies = match &issue.dependencies {
                         None => String::from("   "),
@@ -331,18 +331,18 @@ fn handle_command(
                 print!("dependencies: ");
                 let mut separator = "";
                 for dep_id in dependencies {
-                    let Some(d) = issues.get_issue(dep_id) else {
-                        continue;
+                    let emoji = match issues.get_issue(dep_id) {
+                        None => "☠️ ",
+                        Some(d) => match d.state {
+                            entomologist::issue::State::New => "⌛",
+                            entomologist::issue::State::Backlog => "⌛",
+                            entomologist::issue::State::Blocked => "⌛",
+                            entomologist::issue::State::InProgress => "⌛",
+                            entomologist::issue::State::Done => "✅",
+                            entomologist::issue::State::WontDo => "❌",
+                        },
                     };
-                    let emoji = match d.state {
-                        entomologist::issue::State::New => "⌛",
-                        entomologist::issue::State::Backlog => "⌛",
-                        entomologist::issue::State::Blocked => "⌛",
-                        entomologist::issue::State::InProgress => "⌛",
-                        entomologist::issue::State::Done => "✅",
-                        entomologist::issue::State::WontDo => "❌",
-                    };
-                    print!("{}{}{}", separator, emoji, dep_id);
+                    print!("{}{} {}", separator, emoji, dep_id);
                     separator = ", "
                 }
                 println!();


### PR DESCRIPTION
ent show:
```
    issue 87fa3146b90db61c4ea0de182798a0e5
    author: sigil-03 <sigil@glyphs.tech>
    tags: issue, perf
    creation_time: 2025-07-18 16:36:54 -06:00
    state: InProgress
    dependencies: ✅478ac34c204be06b1da5b4f0b5a2532d, ⌛50012ba39d8dac21ac122affe92c4160
    assignee: seb
```

ent list:
```
    87fa3146b90db61c4ea0de182798a0e5  🗨️4 ⌛1  large ent repositories are slow (👉 seb) [issue, perf]
    50012ba39d8dac21ac122affe92c4160  🗨️1      store Author and Creation-time of Issue & Comment as files, don't run `git log` (👉 seb) [perf]
    cffd805252f9a2b4373abf7852d9e750  🗨️1      make generic Entry<T> type which can get put in FS (👉 sigil-03)
```