### PR TITLE
Handle missing entomologist data branch

### DIFF
--- a/src/bin/ent/main.rs
+++ b/src/bin/ent/main.rs
@@ -624,12 +624,6 @@ fn main() -> anyhow::Result<()> {
         }
     };
 
-    if let entomologist::database::IssuesDatabaseSource::Branch(branch) = issues_database_source {
-        if !entomologist::git::git_branch_exists(branch)? {
-            entomologist::git::create_orphan_branch(branch)?;
-        }
-    }
-
     handle_command(&args, &issues_database_source)?;
 
     Ok(())

--- a/src/database.rs
+++ b/src/database.rs
@@ -67,6 +67,7 @@ pub fn make_issues_database(
             worktree: None,
         }),
         IssuesDatabaseSource::Branch(branch) => {
+            crate::git::ensure_branch_exists(branch)?;
             let worktree = match access_type {
                 IssuesDatabaseAccess::ReadOnly => crate::git::Worktree::new_detached(branch)?,
                 IssuesDatabaseAccess::ReadWrite => crate::git::Worktree::new(branch)?,

--- a/src/git.rs
+++ b/src/git.rs
@@ -125,6 +125,43 @@ pub fn git_branch_exists(branch: &str) -> Result<bool, GitError> {
     Ok(result.status.success())
 }
 
+pub fn ensure_branch_exists(branch: &str) -> Result<(), GitError> {
+    // Check for a local branch with the specified name.
+    if git_branch_exists(&format!("refs/heads/{branch}"))? {
+        return Ok(());
+    }
+
+    // Check for *any* branch with the specified name, even remote.
+    let result = std::process::Command::new("git")
+        .args(["show-ref", branch])
+        .output()?;
+    match result.status.success() {
+        true => {
+            // Some remote has this branch, make a local branch from
+            // the first one found.
+            let output = String::from_utf8_lossy(&result.stdout);
+            let line = output.split('\n').next().ok_or(GitError::Oops)?;
+            let remote_branch = line.split_whitespace().last().ok_or(GitError::Oops)?;
+
+            let result = std::process::Command::new("git")
+                .args(["branch", branch, remote_branch])
+                .output()?;
+            if !result.status.success() {
+                println!("failed to make branch {branch:?} from remote branch {remote_branch:?}");
+                println!("stdout: {}", &String::from_utf8_lossy(&result.stdout));
+                println!("stderr: {}", &String::from_utf8_lossy(&result.stderr));
+                return Err(GitError::Oops);
+            }
+        }
+        false => {
+            // No remote has this branch, make an empty one locally now.
+            create_orphan_branch(branch)?;
+        }
+    }
+
+    Ok(())
+}
+
 pub fn worktree_is_dirty(dir: &str) -> Result<bool, GitError> {
     // `git status --porcelain` prints a terse list of files added or
     // modified (both staged and not), and new untracked files.  So if

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,77 @@
+/// Create a tempdir with automatic cleanup-on-drop, initialize a git
+/// repo in it, and create a valid `master` branch.
+pub fn make_test_repo() -> tempfile::TempDir {
+    // Create tempdir.
+    let workdir = tempfile::tempdir().unwrap();
+
+    // Make a git repo in it.
+    let result = std::process::Command::new("git")
+        .args(["init", &workdir.path().to_string_lossy()])
+        .output()
+        .unwrap();
+    if !result.status.success() {
+        println!("failed to git init in {}", workdir.path().to_string_lossy());
+        println!("stdout:\n{}", &String::from_utf8_lossy(&result.stdout));
+        println!("stderr:\n{}", &String::from_utf8_lossy(&result.stderr));
+        panic!();
+    }
+
+    // Make an empty commit in the master branch so it's normal and valid.
+    let result = std::process::Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "empty commit"])
+        .current_dir(&workdir.path())
+        .output()
+        .unwrap();
+    if !result.status.success() {
+        println!(
+            "failed to git commit in {}",
+            workdir.path().to_string_lossy()
+        );
+        println!("stdout:\n{}", &String::from_utf8_lossy(&result.stdout));
+        println!("stderr:\n{}", &String::from_utf8_lossy(&result.stderr));
+        panic!();
+    }
+
+    workdir
+}
+
+/// Create an `entomologist-data` branch.
+/// FIXME: By branching HEAD :-(
+#[allow(dead_code)]
+pub fn make_entomologist_branch(git_worktree: &std::path::Path) {
+    let result = std::process::Command::new("git")
+        .args(["branch", "entomologist-data"])
+        .current_dir(git_worktree)
+        .output()
+        .unwrap();
+    if !result.status.success() {
+        println!("failed to git branch in {}", git_worktree.to_string_lossy());
+        println!("stdout:\n{}", &String::from_utf8_lossy(&result.stdout));
+        println!("stderr:\n{}", &String::from_utf8_lossy(&result.stderr));
+        panic!();
+    }
+}
+
+#[allow(dead_code)]
+pub fn clone_repo(remote_repo: &std::path::Path) -> tempfile::TempDir {
+    let workdir = tempfile::tempdir().unwrap();
+
+    let result = std::process::Command::new("git")
+        .args([
+            "clone",
+            &remote_repo.to_string_lossy(),
+            &workdir.path().to_string_lossy(),
+        ])
+        .output()
+        .unwrap();
+    if !result.status.success() {
+        println!("stdout: {}", &String::from_utf8_lossy(&result.stdout));
+        println!("stderr: {}", &String::from_utf8_lossy(&result.stderr));
+        panic!(
+            "failed to git clone in {}",
+            workdir.path().to_string_lossy()
+        );
+    }
+
+    workdir
+}

--- a/tests/local-entomologist-data-branch-exists-ro.rs
+++ b/tests/local-entomologist-data-branch-exists-ro.rs
@@ -1,0 +1,16 @@
+mod common;
+
+#[test]
+fn local_entomologist_data_branch_exists_ro() {
+    let repo = common::make_test_repo();
+    std::env::set_current_dir(&repo).unwrap();
+    common::make_entomologist_branch(&repo.path());
+
+    let db = entomologist::database::make_issues_database(
+        &entomologist::database::IssuesDatabaseSource::Branch("entomologist-data"),
+        entomologist::database::IssuesDatabaseAccess::ReadOnly,
+    )
+    .unwrap();
+
+    let _issues = entomologist::issues::Issues::new_from_dir(&db.dir).unwrap();
+}

--- a/tests/local-entomologist-data-branch-exists-rw.rs
+++ b/tests/local-entomologist-data-branch-exists-rw.rs
@@ -1,0 +1,16 @@
+mod common;
+
+#[test]
+fn local_entomologist_data_branch_exists_rw() {
+    let repo = common::make_test_repo();
+    std::env::set_current_dir(&repo).unwrap();
+    common::make_entomologist_branch(&repo.path());
+
+    let db = entomologist::database::make_issues_database(
+        &entomologist::database::IssuesDatabaseSource::Branch("entomologist-data"),
+        entomologist::database::IssuesDatabaseAccess::ReadWrite,
+    )
+    .unwrap();
+
+    let _issues = entomologist::issues::Issues::new_from_dir(&db.dir).unwrap();
+}

--- a/tests/no-entomologist-data-branch-exists-ro.rs
+++ b/tests/no-entomologist-data-branch-exists-ro.rs
@@ -1,0 +1,17 @@
+mod common;
+
+#[test]
+/// No `entomologist-data` branch, local or remote.
+fn no_entomologist_data_branch_exists_ro() {
+    let workdir = common::make_test_repo();
+    std::env::set_current_dir(&workdir).unwrap();
+    println!("{workdir:?}");
+
+    let db = entomologist::database::make_issues_database(
+        &entomologist::database::IssuesDatabaseSource::Branch("entomologist-data"),
+        entomologist::database::IssuesDatabaseAccess::ReadOnly,
+    )
+    .unwrap();
+
+    let _issues = entomologist::issues::Issues::new_from_dir(&db.dir).unwrap();
+}

--- a/tests/no-entomologist-data-branch-exists-rw.rs
+++ b/tests/no-entomologist-data-branch-exists-rw.rs
@@ -1,0 +1,17 @@
+mod common;
+
+#[test]
+/// No `entomologist-data` branch, local or remote.
+fn no_entomologist_data_branch_exists_rw() {
+    let workdir = common::make_test_repo();
+    std::env::set_current_dir(&workdir).unwrap();
+    println!("{workdir:?}");
+
+    let db = entomologist::database::make_issues_database(
+        &entomologist::database::IssuesDatabaseSource::Branch("entomologist-data"),
+        entomologist::database::IssuesDatabaseAccess::ReadWrite,
+    )
+    .unwrap();
+
+    let _issues = entomologist::issues::Issues::new_from_dir(&db.dir).unwrap();
+}

--- a/tests/remote-entomologist-data-branch-exists-ro.rs
+++ b/tests/remote-entomologist-data-branch-exists-ro.rs
@@ -1,0 +1,21 @@
+mod common;
+
+#[test]
+fn remote_entomologist_data_branch_exists_ro() {
+    // Make a temporary repo with an `entomologist-data` branch in it.
+    let remote_repo = common::make_test_repo();
+    std::env::set_current_dir(&remote_repo).unwrap();
+    common::make_entomologist_branch(&remote_repo.path());
+
+    // Clone the "remote" repo into another temporary repo.
+    let local_repo = common::clone_repo(&remote_repo.path());
+    std::env::set_current_dir(&local_repo).unwrap();
+
+    let db = entomologist::database::make_issues_database(
+        &entomologist::database::IssuesDatabaseSource::Branch("entomologist-data"),
+        entomologist::database::IssuesDatabaseAccess::ReadOnly,
+    )
+    .unwrap();
+
+    let _issues = entomologist::issues::Issues::new_from_dir(&db.dir).unwrap();
+}

--- a/tests/remote-entomologist-data-branch-exists-rw.rs
+++ b/tests/remote-entomologist-data-branch-exists-rw.rs
@@ -1,0 +1,21 @@
+mod common;
+
+#[test]
+fn remote_entomologist_data_branch_exists_rw() {
+    // Make a temporary repo with an `entomologist-data` branch in it.
+    let remote_repo = common::make_test_repo();
+    std::env::set_current_dir(&remote_repo).unwrap();
+    common::make_entomologist_branch(&remote_repo.path());
+
+    // Clone the "remote" repo into another temporary repo.
+    let local_repo = common::clone_repo(&remote_repo.path());
+    std::env::set_current_dir(&local_repo).unwrap();
+
+    let db = entomologist::database::make_issues_database(
+        &entomologist::database::IssuesDatabaseSource::Branch("entomologist-data"),
+        entomologist::database::IssuesDatabaseAccess::ReadWrite,
+    )
+    .unwrap();
+
+    let _issues = entomologist::issues::Issues::new_from_dir(&db.dir).unwrap();
+}


### PR DESCRIPTION
This teaches `entomologist::database::make_issues_database()` to make sure the `entomologist-data` branch exists before trying to access it.

We do this in three stages:
1. If there's a local branch (`refs/heads/entomologist-data`) we're good, just use that.
2. If there's a remote branch (`refs/remotes/*/entomologist-data`), create a local branch from the first one of those we found.
3. Last ditch, create a new empty `entomologist-data` branch. 

Also add tests of these different conditions.